### PR TITLE
fix: https is a requirement in the latest RN

### DIFF
--- a/android/adapters/bridge_adapter/build.gradle
+++ b/android/adapters/bridge_adapter/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     repositories {
         maven { url 'https://maven.aliyun.com/repository/google' }
         maven { url 'https://maven.aliyun.com/repository/jcenter' }
-        maven { url 'http://maven.aliyun.com/nexus/content/groups/public' }
+        maven { url 'https://maven.aliyun.com/nexus/content/groups/public' }
         //本地库，local repository(${user.home}/.m2/repository)
         jcenter()
         mavenCentral()

--- a/android/bridge_spec/build.gradle
+++ b/android/bridge_spec/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     repositories {
         maven { url 'https://maven.aliyun.com/repository/google' }
         maven { url 'https://maven.aliyun.com/repository/jcenter' }
-        maven { url 'http://maven.aliyun.com/nexus/content/groups/public' }
+        maven { url 'https://maven.aliyun.com/nexus/content/groups/public' }
         //本地库，local repository(${user.home}/.m2/repository)
         mavenCentral()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ allprojects {
     repositories {
         maven { url 'https://maven.aliyun.com/repository/google' }
         maven { url 'https://maven.aliyun.com/repository/jcenter' }
-        maven { url 'http://maven.aliyun.com/nexus/content/groups/public' }
+        maven { url 'https://maven.aliyun.com/nexus/content/groups/public' }
         google()
         maven {
             url 'https://maven.google.com/'
@@ -23,7 +23,7 @@ buildscript {
     repositories {
         maven { url 'https://maven.aliyun.com/repository/google' }
         maven { url 'https://maven.aliyun.com/repository/jcenter' }
-        maven { url 'http://maven.aliyun.com/nexus/content/groups/public' }
+        maven { url 'https://maven.aliyun.com/nexus/content/groups/public' }
         google()
         maven {
             url 'https://maven.google.com/'


### PR DESCRIPTION
fixes #34 

```
A problem occurred configuring project ':android:adapters:bridge_adapter'.
> Could not resolve all dependencies for configuration ':android:adapters:bridge_adapter:classpath'.
   > Using insecure protocols with repositories, without explicit opt-in, is unsupported. Switch Maven repository 'maven3(http://maven.aliyun.com/nexus/content/groups/public)' to redirect to a secure protocol (like HTTPS) or allow insecure protocols. See https://docs.gradle.org/7.2/dsl/org.gradle.api.artifacts.repositories.UrlArtifactRepository.html#org.gradle.api.artifacts.repositories.UrlArtifactRepository:allowInsecureProtocol for more details. 

```